### PR TITLE
Remove usages of `django.utils.importlib`

### DIFF
--- a/gutter/django/autodiscovery.py
+++ b/gutter/django/autodiscovery.py
@@ -1,4 +1,5 @@
 import logging
+from importlib import import_module
 
 
 logger = logging.getLogger(__name__)
@@ -10,7 +11,6 @@ def discover():
     INSTALLED_APPS.
     """
     from django.conf import settings
-    from django.utils.importlib import import_module
 
     for app in settings.INSTALLED_APPS:
         module = '%s.gutter' % app


### PR DESCRIPTION
It will be removed in django 1.9:
https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-1-9

and throws this warning in django 1.8:

> py.warnings WARNING: .venv/src/gutter-django/gutter/django/autodiscovery.py:13: RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9.
