### PR TITLE
Stop using `django.conf.urls.patterns`

### DIFF
--- a/gutter/django/nexus_modules.py
+++ b/gutter/django/nexus_modules.py
@@ -49,17 +49,16 @@ class GutterModule(nexus.NexusModule):
 
     def get_urls(self):
         try:
-            from django.conf.urls import patterns, url
+            from django.conf.urls import url
         except ImportError:
-            from django.conf.urls.defaults import patterns, url
+            from django.conf.urls.defaults import url
 
-        urlpatterns = patterns(
-            '',
+        urlpatterns = [
             url(r'^update/$', self.as_view(self.update), name='update'),
             url(r'^export/$', self.as_view(self.export_switches), name='export'),
             url(r'^import/$', self.as_view(self.import_switches), name='import'),
             url(r'^$', self.as_view(self.index), name='index'),
-        )
+        ]
 
         return urlpatterns
 


### PR DESCRIPTION
As per the django 1.8 release notes:
https://docs.djangoproject.com/en/1.8/releases/1.8/#django-conf-urls-patterns

To quiet these DeprecationWarnings:

> 2016-07-30 16:15:56,819 py.warnings WARNING: .../.venv/src/gutter-django/gutter/django/nexus_modules.py:61: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
>   url(r'^$', self.as_view(self.index), name='index'),
